### PR TITLE
Internet explorer 8 fix

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -187,7 +187,7 @@ var hinclude;
         string = content;
       }
       if (this.detectIe7_8()) {
-        include[0].appendChild(this.fixInnerHtml(string));
+        include[0].parentNode.replaceChild(this.fixInnerHtml(string), include[0]);
       } else {
         if (!hinclude.isEmpty(include[0])) {
           include[0].innerHTML = string;


### PR DESCRIPTION
IE8 will rise an exception in some cases if you append content to an unknown element (xh:include...)
